### PR TITLE
nextjsの画像形式に対応、その他

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,11 +32,12 @@ class ResourceCollection {
     private readonly router: GotoPageWithWait,
     private readonly Rurls: ResourceUrls,
     private readonly salvage: Salvage,
-    private readonly logger: Logger
+    private readonly logger: Logger,
   ) {
     this.props = {
+      base_url: ENV.RECIPE.base_url,
       surveyUrls: ENV.RECIPE.survey.subdir.map(
-        (leaf) => new URL(leaf, ENV.RECIPE.base_url).href
+        (leaf) => new URL(leaf, ENV.RECIPE.base_url).href,
       ),
       surveyAnchor: ENV.RECIPE.survey.anchor,
       target: ENV.RECIPE.target,
@@ -57,7 +58,10 @@ class ResourceCollection {
    * @memberof ResourceCollection
    */
   private async resourcesDownload(pageUrl: string, page: Page): Promise<void> {
-    const saveDir = path.join(this.ENV.DATA_DIR, escapeFileName(pageUrl));
+    const baseDir = this.ENV.DATA_DIR;
+    const dirForBaseUrl = escapeFileName(this.props.base_url);
+    const dirForleaf = escapeFileName(pageUrl);
+    const saveDir = path.join(baseDir, dirForBaseUrl, dirForleaf);
 
     // 保存先のディレクトリを作成
     try {
@@ -69,7 +73,6 @@ class ResourceCollection {
     // ページを開く
     await this.router.transion(pageUrl, page);
     console.log(`[moved]: ${pageUrl}`);
-
     // ページのタイトルを取得して保存
     await this.salvage.storeText({
       page,
@@ -104,8 +107,9 @@ class ResourceCollection {
     // アクセスログのディレクトリが存在しない場合は作成してログファイルを作成
     const logDir = path.dirname(this.ENV.ACCESS_LOG);
     if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
-    if (!fs.existsSync(this.ENV.ACCESS_LOG))
+    if (!fs.existsSync(this.ENV.ACCESS_LOG)) {
       fs.writeFileSync(this.ENV.ACCESS_LOG, "", "utf-8");
+    }
 
     // 訪問済みのページを読み込む
     this.visitedPages = fs

--- a/src/app.ts
+++ b/src/app.ts
@@ -129,11 +129,11 @@ class ResourceCollection {
           console.log(`[skipped]: ${url}\n`);
           continue;
         }
+
         // リソースをダウンロード
         await this.pullResources.exec({
           targetUrl: url,
           pageForPuppeteer: page,
-          env: this.ENV,
           router: this.router,
           propsForCollection: this.props,
           salvage: this.salvage,

--- a/src/app.ts
+++ b/src/app.ts
@@ -104,16 +104,26 @@ class ResourceCollection {
     const page = await browser.newPage();
     page.setUserAgent(this.ENV.PUPPETEER.USER_AGENT);
 
-    // アクセスログのディレクトリが存在しない場合は作成してログファイルを作成
-    const logDir = path.dirname(this.ENV.ACCESS_LOG);
-    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
-    if (!fs.existsSync(this.ENV.ACCESS_LOG)) {
-      fs.writeFileSync(this.ENV.ACCESS_LOG, "", "utf-8");
+    // 必要なディレクトリやファイルが存在しない場合は作成
+    try {
+      if (!fs.existsSync(this.ENV.DATA_DIR)) {
+        fs.mkdirSync(this.ENV.DATA_DIR, { recursive: true });
+      }
+
+      if (!fs.existsSync(this.ENV.ACCESS_LOG_DIR)) {
+        fs.mkdirSync(this.ENV.ACCESS_LOG_DIR, { recursive: true });
+      }
+
+      if (!fs.existsSync(this.ENV.ACCESS_LOG_FILE)) {
+        fs.writeFileSync(this.ENV.ACCESS_LOG_FILE, "", "utf-8");
+      }
+    } catch (e: any) {
+      console.error(e.message);
     }
 
     // 訪問済みのページを読み込む
     this.visitedPages = fs
-      .readFileSync(this.ENV.ACCESS_LOG, "utf-8")
+      .readFileSync(this.ENV.ACCESS_LOG_FILE, "utf-8")
       .trim()
       .split("\n")
       .map((row) => {
@@ -160,7 +170,10 @@ class ResourceCollection {
       await browser.close();
       // 訪問済みのページを保存
       if (this.addLoggedPages.length > 0) {
-        this.logger.storeVisitedLink(this.addLoggedPages, this.ENV.ACCESS_LOG);
+        this.logger.storeVisitedLink(
+          this.addLoggedPages,
+          this.ENV.ACCESS_LOG_FILE,
+        );
       }
     }
   }

--- a/src/constants/environment.ts
+++ b/src/constants/environment.ts
@@ -9,10 +9,12 @@ import { Recipe } from "~/types";
 export default class ENV {
   /** アプリケーションのルートディレクトリ */
   APP_ROOT = path.resolve("~/../");
-  /** ログファイルの保存先 */
-  ACCESS_LOG = path.join(this.APP_ROOT, ".log/access.log");
-  /** リソースの保存先 */
+  /** リソースの保存ディレクトリ */
   DATA_DIR = path.join(this.APP_ROOT, ".temp");
+  /** ログファイルの保存ディレクトリ */
+  ACCESS_LOG_DIR = path.join(this.DATA_DIR, ".logs");
+  /** ログファイルの保存先 */
+  ACCESS_LOG_FILE = path.join(this.ACCESS_LOG_DIR, "access.log");
   /** puppeteerの設定 */
   PUPPETEER = {
     /** 初期化時のconfig */

--- a/src/constants/environment.ts
+++ b/src/constants/environment.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { Recipe } from "~/types";
 
 /**
- * 環境変数を管理する
+ * 定数を管理する
  * @class ENV
  */
 export default class ENV {

--- a/src/modules/PullResources.ts
+++ b/src/modules/PullResources.ts
@@ -9,14 +9,21 @@ import type { GotoPageWithWait } from "./GotoPageWithWait";
 import type { Salvage } from "./Salvage";
 
 type PullResourcesProps = {
+  /** 対象ページのURL */
   targetUrl: string;
+  /** PuppeteerのPageオブジェクト */
   pageForPuppeteer: Page;
-  env: ENV;
+  /** ページ遷移用の関数 */
   router: GotoPageWithWait;
+  /** リソース収集の設定 */
   propsForCollection: Props;
+  /** リソースを保存するクラス */
   salvage: Salvage;
 };
 export class PullResources {
+  // 定数を取得
+  env: ENV = new ENV();
+
   /**
    * 指定したページのリソースをダウンロードする
    * @public
@@ -28,12 +35,11 @@ export class PullResources {
     const {
       targetUrl,
       pageForPuppeteer,
-      env,
       router,
       propsForCollection,
       salvage,
     } = props;
-    const baseDir = env.DATA_DIR;
+    const baseDir = this.env.DATA_DIR;
     const dirForBaseUrl = escapeFileName(propsForCollection.base_url);
     const dirForleaf = escapeFileName(targetUrl);
     const saveDir = path.join(baseDir, dirForBaseUrl, dirForleaf);

--- a/src/modules/PullResources.ts
+++ b/src/modules/PullResources.ts
@@ -1,0 +1,68 @@
+import fs from "fs";
+import path from "path";
+import type { Page } from "puppeteer";
+
+import ENV from "~/constants/environment";
+import type { Props } from "~/types";
+import { escapeFileName } from "~/utils";
+import type { GotoPageWithWait } from "./GotoPageWithWait";
+import type { Salvage } from "./Salvage";
+
+type PullResourcesProps = {
+  targetUrl: string;
+  pageForPuppeteer: Page;
+  env: ENV;
+  router: GotoPageWithWait;
+  propsForCollection: Props;
+  salvage: Salvage;
+};
+export class PullResources {
+  /**
+   * 指定したページのリソースをダウンロードする
+   * @public
+   * @param {PullResourcesProps} props
+   * @return {Promise<void>}
+   * @memberof PullResources
+   */
+  public async exec(props: PullResourcesProps): Promise<void> {
+    const {
+      targetUrl,
+      pageForPuppeteer,
+      env,
+      router,
+      propsForCollection,
+      salvage,
+    } = props;
+    const baseDir = env.DATA_DIR;
+    const dirForBaseUrl = escapeFileName(propsForCollection.base_url);
+    const dirForleaf = escapeFileName(targetUrl);
+    const saveDir = path.join(baseDir, dirForBaseUrl, dirForleaf);
+
+    // 保存先のディレクトリを作成
+    try {
+      fs.mkdirSync(saveDir, { recursive: true });
+    } catch (e: any) {
+      console.error(e.message);
+    }
+
+    // ページを開く
+    await router.transion(targetUrl, pageForPuppeteer);
+    console.log(`[moved]: ${targetUrl}`);
+
+    // ページのタイトルを取得して保存
+    await salvage.storeText({
+      page: pageForPuppeteer,
+      selector: propsForCollection.target.title,
+      filePath: path.join(saveDir, "title.txt"),
+    });
+
+    // ページ内の画像のurlを取得後、画像ページに遷移してからダウンロード
+    await salvage.storeImages({
+      page: pageForPuppeteer,
+      selector: propsForCollection.target.items,
+      router: router,
+      saveDir,
+      thumbnail: propsForCollection.thumbnail,
+    });
+  }
+}

--- a/src/modules/Salvage.ts
+++ b/src/modules/Salvage.ts
@@ -68,6 +68,9 @@ export class Salvage {
 
     // 画像ページに遷移してからダウンロード
     for (let imageUrl of filteringUrls) {
+      // base64形式の画像は保存しない
+      if (/base64/.test(imageUrl)) continue;
+
       const res = await router.transion(imageUrl, page);
       if (res?.ok() == null) continue;
       const buffer = await res.buffer();

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,4 +1,5 @@
 export { GotoPageWithWait } from "./GotoPageWithWait";
 export { Logger } from "./Logger";
+export { PullResources } from "./PullResources";
 export { ResourceUrls } from "./ResourceUrls";
 export { Salvage } from "./Salvage";

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,7 @@
 /** ResourceCollection内で使用するプロパティの型定義 */
 export interface Props {
+  /** サイトURL */
+  base_url: string;
   /** 索敵ページのurl */
   surveyUrls: string[];
   /** 索敵ページに存在する、ターゲットページ特定するためのアンカー要素のセレクタ */


### PR DESCRIPTION
- refactor: 🔄 保存ディレクトリの構造の変更
- feat: ✨️ (Salvage.ts) 保存するファイル名の変更
- fix: 🐛 base64形式をスキップ
- refactor: 🔄 出力用ディレクトリの構造変更
- refactor: 🔄 (di) 依存の注入
- feat: ✨️ (*) nextjsの画像形式に対応

next/imageモジュールで最適化された画像のダウンロードに対応。
リソースダウンロードモジュールをdi形式に変更。
その他軽微な修正。
