### PR TITLE
非同期読み込み画像への対処と特定のaタグ除外の設定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.2.0](https://github.com/kos-dw/resource-collection/compare/v2.1.0...v2.2.0) (2023-10-08)
+
+
+### Features
+
+* ✨️ (*) nextjsの画像形式に対応 ([cd6c836](https://github.com/kos-dw/resource-collection/commit/cd6c83668b0f535e7f68d622ccfdb83a7d9a6e17))
+* ✨️ (Salvage.ts) 保存するファイル名の変更 ([b0fe8e6](https://github.com/kos-dw/resource-collection/commit/b0fe8e6df5ccc121b0063f0fdf7a9220778134d3))
+
+
+### Bug Fixes
+
+* 🐛 base64形式をスキップ ([1d821ac](https://github.com/kos-dw/resource-collection/commit/1d821acb93973f474f2b0e723b97e21242f4de87))
+
 ## [2.1.0](https://github.com/kos-dw/resource-collection/compare/v2.0.0...v2.1.0) (2023-10-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.2.2](https://github.com/kos-dw/resource-collection/compare/v2.2.1...v2.2.2) (2023-10-10)
+
+
+### Bug Fixes
+
+* 🐛 (*) 非同期読み込みの画像への対処 ([6a591ff](https://github.com/kos-dw/resource-collection/commit/6a591ffff335a01c36146e819223a0ed2e29cfec)), closes [#10](https://github.com/kos-dw/resource-collection/issues/10)
+
 ### [2.2.1](https://github.com/kos-dw/resource-collection/compare/v2.2.0...v2.2.1) (2023-10-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.2.1](https://github.com/kos-dw/resource-collection/compare/v2.2.0...v2.2.1) (2023-10-09)
+
+
+### Bug Fixes
+
+* 🐛 (ResourceUrls.ts) 特定のaタグを除外 ([ee26026](https://github.com/kos-dw/resource-collection/commit/ee260268a7630380dec87f2d6ea2fd04fa80cbfb)), closes [#6](https://github.com/kos-dw/resource-collection/issues/6) [#7](https://github.com/kos-dw/resource-collection/issues/7)
+
 ## [2.2.0](https://github.com/kos-dw/resource-collection/compare/v2.1.0...v2.2.0) (2023-10-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-collection",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-collection",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-collection",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,7 +72,9 @@ class ResourceCollection {
     // Puppeteerの初期化
     const browser = await puppeteer.launch(this.ENV.PUPPETEER.CONFIG);
     const page = await browser.newPage();
-    page.setUserAgent(this.ENV.PUPPETEER.USER_AGENT);
+    if (this.ENV.PUPPETEER.USER_AGENT != null) {
+      page.setUserAgent(this.ENV.PUPPETEER.USER_AGENT);
+    }
 
     // 必要なディレクトリやファイルが存在しない場合は作成
     try {

--- a/src/constants/environment.ts
+++ b/src/constants/environment.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { Recipe } from "~/types";
+import { PuppeteerConfig, Recipe } from "~/types";
 
 /**
  * 定数を管理する
@@ -16,28 +16,15 @@ export default class ENV {
   /** ログファイルの保存先 */
   ACCESS_LOG_FILE = path.join(this.ACCESS_LOG_DIR, "access.log");
   /** puppeteerの設定 */
-  PUPPETEER = {
-    /** 初期化時のconfig */
-    CONFIG: {
-      headless: (() => {
-        switch (process.env.PUPPETEER_ISHEADLESS) {
-          case "true":
-            return true;
-          case "false":
-            return false;
-          case "new":
-            return "new";
-          default:
-            return undefined;
-        }
-      })(),
-      slowMo: 50,
-    } as const,
-    /** ページ遷移時の待機時間 */
-    TRANSION_DELAY: 1500,
-    /** ユーザーエージェント */
-    USER_AGENT: process.env.USER_AGENT || "",
-  };
+  get PUPPETEER() {
+    const puppeteerConfigPath = path.join(this.APP_ROOT, "puppeteer.config.js");
+    if (!fs.existsSync(puppeteerConfigPath)) {
+      console.error(`[error]: puppeteerConfigPath is not found.`);
+      process.exit(1);
+    }
+    const puppeteerConfig: PuppeteerConfig = require(puppeteerConfigPath);
+    return puppeteerConfig;
+  }
   /** レシピ */
   get RECIPE() {
     const recipePath = path.join(this.APP_ROOT, "recipe.config.js");

--- a/src/modules/ResourceUrls.ts
+++ b/src/modules/ResourceUrls.ts
@@ -36,7 +36,7 @@ export class ResourceUrls {
       }, selector);
       integratedUrl = [...new Set([...integratedUrl, ...articles])];
 
-      console.log(`[getting url]: ${url}`);
+      console.log(`[getting url]: from ${url}`);
       console.log(integratedUrl.join("\n"), "\n");
     }
     return integratedUrl;

--- a/src/modules/ResourceUrls.ts
+++ b/src/modules/ResourceUrls.ts
@@ -1,4 +1,5 @@
 import type { Page } from "puppeteer";
+import ENV from "~/constants/environment";
 import type { GotoPageWithWait } from "./GotoPageWithWait";
 
 type Props = {
@@ -13,6 +14,9 @@ type Props = {
 };
 
 export class ResourceUrls {
+  // 定数を取得
+  env: ENV = new ENV();
+
   /**
    * 指定したページのurlを取得する
    * @param {Props}
@@ -24,7 +28,7 @@ export class ResourceUrls {
 
     for (let url of urls) {
       try {
-        await router.transion(url, page);
+        await router.transion(url, page, this.env.PUPPETEER.TRANSION_DELAY);
       } catch (e: any) {
         throw new Error(e.message);
       }

--- a/src/modules/ResourceUrls.ts
+++ b/src/modules/ResourceUrls.ts
@@ -29,9 +29,25 @@ export class ResourceUrls {
         throw new Error(e.message);
       }
       const articles = await page.evaluate((selector) => {
-        const anchors = [
+        let anchors = [
           ...document.querySelectorAll(selector),
         ] as HTMLAnchorElement[];
+
+        // 特定のURLを除外
+        anchors = anchors.filter((a) => {
+          // 除外条件
+          // 1. target属性にblankが含まれる
+          // 2. href属性にjavascriptが含まれる
+          // 3. href属性がtel:またはmailto:で始まる
+          const ignoreCase = [
+            a.getAttribute("target")?.includes("blank"),
+            a.href.includes("javascript"),
+            /^[tel:|mailto:]/.test(a.href),
+          ];
+
+          return !ignoreCase.some((bool) => bool);
+        });
+
         return anchors.map((a) => a.href);
       }, selector);
       integratedUrl = [...new Set([...integratedUrl, ...articles])];

--- a/src/modules/Salvage.ts
+++ b/src/modules/Salvage.ts
@@ -119,12 +119,11 @@ export class Salvage {
     urls = [...new Set(urls)];
 
     // base64形式の画像は除外
-    urls = urls.filter((url) => {
-      return !(/base64/.test(url));
-    });
+    urls = urls.filter((url) => !/base64/.test(url));
 
     // 特定のURLを成形
     urls = urls.map((url) => {
+      // Next.jsのnext/imageモジュール画像のurlを成形
       if (url.includes(stringForDicideToNextls)) {
         const [imageFromNextjs] = url.split(stringForDicideToNextls)[1].split(
           "&",

--- a/src/modules/Salvage.ts
+++ b/src/modules/Salvage.ts
@@ -110,7 +110,6 @@ export class Salvage {
    * @memberof Salvage
    */
   resolveFileUrl(imageUrls: string[]): string[] {
-    console.log(imageUrls);
     // Next.jsの画像のurlを判定するための文字列
     const stringForDicideToNextls = "_next/image?url=";
 

--- a/src/modules/Salvage.ts
+++ b/src/modules/Salvage.ts
@@ -72,12 +72,16 @@ export class Salvage {
 
     // 画像ページに遷移してからダウンロード
     for (let imageUrl of resolvedUrls) {
-      const res = await router.transion(imageUrl, page);
+      const res = await router.transion(
+        imageUrl,
+        page,
+        this.env.PUPPETEER.TRANSION_DELAY,
+      );
       if (res?.ok() == null) continue;
       const buffer = await res.buffer();
 
       try {
-        let timestamp = Date.now().toString().padStart(3, "0");
+        let timestamp = Date.now().toString();
         let extension = path.extname(imageUrl);
         let filename = `image_${timestamp}${extension}`;
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -14,7 +14,7 @@ export interface Props {
   thumbnail: string | boolean;
 }
 
-/* レシピの型定義 */
+/* recipe.config.jsの型定義 */
 export interface Recipe {
   /** サイトURL */
   base_url: string;
@@ -32,4 +32,16 @@ export interface Recipe {
     /** 収集する画像のの要素のセレクタ(querySelectorAllに対応) */
     items: string;
   };
+}
+
+/* puppeteer.config.jsの型定義 */
+export interface PuppeteerConfig {
+  /** 初期化時のconfig */
+  CONFIG: PuppeteerLaunchOptions;
+  /** 画像の非同期読み込み対策スクロールの待機時間 */
+  WAIT_TIME_FOR_SCROLL?: number;
+  /** ページ遷移時の待機時間 */
+  TRANSION_DELAY?: number;
+  /** ユーザーエージェント */
+  USER_AGENT?: string;
 }


### PR DESCRIPTION
- chore: 🎉(release) 2.2.0
- chore: 🎩 標準出力の表示変更
- fix: 🐛 (ResourceUrls.ts) 特定のaタグを除外
- chore: 🎉(release) 2.2.1
- fix: 🐛 (*) 非同期読み込みの画像への対処
- chore: 🎉(release) 2.2.2

スクロール後に読み込まれる画像のダウンロードを実現するために、事前にページの最下部までスクロール。
属性がhref="tel:"、href="mailto:"、target="_blank"の場合は、対象から外す。
その他軽微な修正。
